### PR TITLE
Use cached value in derived atom watcher

### DIFF
--- a/src/okulary/core.cljs
+++ b/src/okulary/core.cljs
@@ -100,11 +100,13 @@
                            ;; As first step we apply the selector to
                            ;; the new source value.
                            new-value   (selector-fn new-source-value)
-                           old-value   (selector-fn old-source-value)]
+                           old-value
+                           (if (and (identical? srccache old-source-value)
+                                    (not (identical? cache EMPTY)))
+                             cache
+                             (selector-fn old-source-value))]
 
-                       ;; Store the new source value in the instance;
-                       ;; this is mainly used by the deref, so this is
-                       ;; just a small performance improvement for it.
+                       ;; Store the new source value in the instance cache
                        (set! srccache new-source-value)
 
                        ;; Cache the new value in the instance.


### PR DESCRIPTION
This change avoids recalculating `old-value` using the `selector` fn if `cache` already contains the correct value. For expensive selector functions this can have a big impact on performance.

It uses the same code as is used in `-deref` to establish validity of the cached value.

I saw there was previously code which attempted to use the cache in watchers but it was removed in https://github.com/funcool/okulary/commit/df32b5ab7c27fbed316af0472b6dbc219b6e55b8 with a comment that it caused race conditions in some situations.

I think there were two issues with the previous code that aren't present in this change:
1. it used queueMicroTask which introduces a delay which could result in a race condition.
2. it didn't check that the `srccache` value matched the `old-source-value` which could result in an incorrect cache value being used.